### PR TITLE
Replace deprecated NuGet properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # TinyPng for .NET
 
-![Version(https://www.nuget.org/packages/TinyPNG/)](https://img.shields.io/nuget/v/tinypng.svg?maxAge=2000)
-[![license](https://img.shields.io/github/license/ctolkien/TinyPNG.svg?maxAge=2592000)]()
-
+[![TinyPNG on NuGet](https://img.shields.io/nuget/v/tinypng.svg?maxAge=2000)](https://www.nuget.org/packages/TinyPNG)
+[![MIT license](https://img.shields.io/github/license/ctolkien/TinyPNG.svg?maxAge=2592000)](LICENSE)
 
 This is a .NET Standard wrapper around the [TinyPNG.com](https://tinypng.com) image compression service. This is not an official TinyPNG.com product.
 
@@ -15,22 +14,22 @@ This is a .NET Standard wrapper around the [TinyPNG.com](https://tinypng.com) im
 Install via Nuget
 
 ```
-    Install-Package TinyPNG
+Install-Package TinyPNG
 ```
 
 Install via `dotnet`
 
 ```
-    dotnet add package TinyPNG
+dotnet add package TinyPNG
 ```
 
 ## Quickstart
 ```csharp
-    using var png = new TinyPngClient("yourSecretApiKey");
-    var result = await png.Compress("cat.jpg");
-    
-    //URL to your compressed version
-    result.Output.Url;
+using var png = new TinyPngClient("yourSecretApiKey");
+var result = await png.Compress("cat.jpg");
+
+//URL to your compressed version
+result.Output.Url;
 ```
 
 ## Upgrading from V2
@@ -39,86 +38,85 @@ The API has changed from V2, primarily you no longer need to await each individu
 step of using the TinyPNG API, you can now chain appropriate calls together as
 the extension methods now operate on `Task<T>`.
 
-
 ## Compressing Images
 
 ```csharp
-    // create an instance of the TinyPngClient
-    using var png = new TinyPngClient("yourSecretApiKey");
-    
-    // Create a task to compress an image.
-    // this gives you the information about your image as stored by TinyPNG
-    // they don't give you the actual bits (as you may want to chain this with a resize
-    // operation without caring for the originally sized image).
-    var compressImageTask = png.Compress("pathToFile or byte array or stream");
-    // or `CompressFromUrl` if compressing from a remotely hosted image.
-    var compressFromUrlImageTask = png.CompressFromUrl("image url");
+// create an instance of the TinyPngClient
+using var png = new TinyPngClient("yourSecretApiKey");
 
-    // If you want to actually save this compressed image off
-    // it will need to be downloaded 
-    var compressedImage = await compressImageTask.Download();
-    
-    // you can then get the bytes
-    var bytes = await compressedImage.GetImageByteData();
-    
-    // get a stream instead
-    var stream = await compressedImage.GetImageStreamData();
-    
-    // or just save to disk
-    await compressedImage.SaveImageToDisk("pathToSaveImage");
-    
-    // Putting it all together
-    await png.Compress("path")
-             .Download()
-             .SaveImageToDisk("savedPath");
+// Create a task to compress an image.
+// this gives you the information about your image as stored by TinyPNG
+// they don't give you the actual bits (as you may want to chain this with a resize
+// operation without caring for the originally sized image).
+var compressImageTask = png.Compress("pathToFile or byte array or stream");
+// or `CompressFromUrl` if compressing from a remotely hosted image.
+var compressFromUrlImageTask = png.CompressFromUrl("image url");
+
+// If you want to actually save this compressed image off
+// it will need to be downloaded
+var compressedImage = await compressImageTask.Download();
+
+// you can then get the bytes
+var bytes = await compressedImage.GetImageByteData();
+
+// get a stream instead
+var stream = await compressedImage.GetImageStreamData();
+
+// or just save to disk
+await compressedImage.SaveImageToDisk("pathToSaveImage");
+
+// Putting it all together
+await png.Compress("path")
+            .Download()
+            .SaveImageToDisk("savedPath");
 ```
 
 Further details about the result of the compression are also available on the `Input` and `Output` properties of a `Compress` operation. Some examples:
 ```csharp
-    var result = await png.Compress("pathToFile or byte array or stream");
-    
-    // old size
-    result.Input.Size;
-    
-    // new size
-    result.Output.Size;
-    
-    // URL of the compressed Image
-    result.Output.Url; 
+var result = await png.Compress("pathToFile or byte array or stream");
+
+// old size
+result.Input.Size;
+
+// new size
+result.Output.Size;
+
+// URL of the compressed Image
+result.Output.Url;
 ```
 
 ## Resizing Images
 
 ```csharp
-    using var png = new TinyPngClient("yourSecretApiKey");
-    
-    var compressImageTask = png.Compress("pathToFile or byte array or stream");
-    
-    var resizedImageTask = compressImageTask.Resize(width, height);
-    
-    await resizedImageTask.SaveImageToDisk("pathToSaveImage");
-    
-    // altogether now....
-    await png.Compress("pathToFile")
-             .Resize(width, height)
-             .SaveImageToDisk("pathToSaveImage");
+using var png = new TinyPngClient("yourSecretApiKey");
+
+var compressImageTask = png.Compress("pathToFile or byte array or stream");
+
+var resizedImageTask = compressImageTask.Resize(width, height);
+
+await resizedImageTask.SaveImageToDisk("pathToSaveImage");
+
+// altogether now....
+await png.Compress("pathToFile")
+            .Resize(width, height)
+            .SaveImageToDisk("pathToSaveImage");
 ```
 
 ### Resize Operations
 
 There are certain combinations when specifying resize options which aren't compatible with
-TinyPNG. We also include strongly typed resize operations, 
-depending on the type of resize you want to do. 
+TinyPNG. We also include strongly typed resize operations,
+depending on the type of resize you want to do.
 
 ```csharp
-    using var png = new TinyPngClient("yourSecretApiKey");
-    
-    var compressTask = png.Compress("pathToFile or byte array or stream");
-    
-    await compressTask.Resize(new ScaleWidthResizeOperation(width));
-    await compressTask.Resize(new ScaleHeightResizeOperation(height));
-    await compressTask.Resize(new FitResizeOperation(width, height));
-    await compressTask.Resize(new CoverResizeOperation(width, height));
+using var png = new TinyPngClient("yourSecretApiKey");
+
+var compressTask = png.Compress("pathToFile or byte array or stream");
+
+await compressTask.Resize(new ScaleWidthResizeOperation(width));
+await compressTask.Resize(new ScaleHeightResizeOperation(height));
+await compressTask.Resize(new FitResizeOperation(width, height));
+await compressTask.Resize(new CoverResizeOperation(width, height));
 ```
 
 The same `Byte[]`, `Stream`, `File` and `Url` path API's are available from the result of the `Resize()` method.
@@ -131,32 +129,32 @@ the appropriate S3 access.
 If you're going to be storing images for most requests onto S3, then you can pass in an `AmazonS3Configuration` object to the constructor.
 
 ```csharp
-    using var png = new TinyPngClient("yourSecretApiKey",
-        new AmazonS3Configuration("awsAccessKeyId", "awsSecretAccessKey", "bucket", "region"));
-    
-    var compressedCat = await png.Compress("cat.jpg");
-    var s3Uri = await png.SaveCompressedImageToAmazonS3(compressedCat, "file-name.png");
-    
-    // If you'd like to override the particular bucket or region
-    // an image is being stored to from what is specified in the AmazonS3Configuration:
-    var s3UriInNewSpot = await png.SaveCompressedImageToAmazonS3(
-        compressedCat,
-        "file-name.png",
-        bucketOverride: "different-bucket",
-        regionOverride: "different-region");
+using var png = new TinyPngClient("yourSecretApiKey",
+    new AmazonS3Configuration("awsAccessKeyId", "awsSecretAccessKey", "bucket", "region"));
+
+var compressedCat = await png.Compress("cat.jpg");
+var s3Uri = await png.SaveCompressedImageToAmazonS3(compressedCat, "file-name.png");
+
+// If you'd like to override the particular bucket or region
+// an image is being stored to from what is specified in the AmazonS3Configuration:
+var s3UriInNewSpot = await png.SaveCompressedImageToAmazonS3(
+    compressedCat,
+    "file-name.png",
+    bucketOverride: "different-bucket",
+    regionOverride: "different-region");
 ```
 
 You can also pass a `AmazonS3Configuration` object directly into calls to `SaveCompressedImageToAmazonS3`
 
 ```csharp
-    using var png = new TinyPngClient("yourSecretApiKey");
-    var compressedCat = await png.Compress("cat.jpg");
-    var s3Uri = await png.SaveCompressedImageToAmazonS3(compressedCat,
-        new AmazonS3Configuration(
-            "awsAccessKeyId",
-            "awsSecretAccessKey",
-            "bucket",
-            "region"), "file-name.png");
+using var png = new TinyPngClient("yourSecretApiKey");
+var compressedCat = await png.Compress("cat.jpg");
+var s3Uri = await png.SaveCompressedImageToAmazonS3(compressedCat,
+    new AmazonS3Configuration(
+        "awsAccessKeyId",
+        "awsSecretAccessKey",
+        "bucket",
+        "region"), "file-name.png");
 ```
 
 
@@ -166,8 +164,8 @@ You can get a read on the number of compression operations you've performed by i
 on the result of any operation you've performed. This is useful for keeping tabs on your API usage.
 
 ```csharp
-    var compressedCat = await png.Compress("cat.jpg");
-    compressedCat.CompressionCount; // = 5
+var compressedCat = await png.Compress("cat.jpg");
+compressedCat.CompressionCount; // = 5
 ```
 
 ## HttpClient
@@ -175,6 +173,6 @@ on the result of any operation you've performed. This is useful for keeping tabs
 TinyPngClient can take HttpClient, which can be controlled from outside the library.
 
 ```csharp
-    var httpClient = new HttpClient();
-    var png = new TinyPngClient("yourSecretApiKey", httpClient);
+var httpClient = new HttpClient();
+var png = new TinyPngClient("yourSecretApiKey", httpClient);
 ```

--- a/src/TinyPNG/TinyPNG.csproj
+++ b/src/TinyPNG/TinyPNG.csproj
@@ -9,10 +9,10 @@
     <AssemblyName>TinyPNG</AssemblyName>
     <PackageId>TinyPNG</PackageId>
     <PackageTags>tinypng;images;compression;jpg;png</PackageTags>
-    <PackageIconUrl>https://raw.githubusercontent.com/ctolkien/TinyPNG/master/icon.png</PackageIconUrl>
+    <PackageIcon>icon.png</PackageIcon>
     <PackageDescription>This is a .NET Standard wrapper around the http://tinypng.com image compression service.</PackageDescription>
     <PackageProjectUrl>https://github.com/ctolkien/TinyPNG</PackageProjectUrl>
-    <PackageLicenseUrl>http://opensource.org/licenses/MIT</PackageLicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReleaseNotes>
 * 3.3 - Support for netstandard 2.0. Added compress from URL feature thanks to @d-ugarov
 * 3.1 - Fixed bug to do with disposed HttpClient
@@ -24,12 +24,16 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
-  
+
   <!-- Deterministic builds -->
   <PropertyGroup Condition="'$(TF_BUILD)' == 'true'">
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
-  
+
+  <ItemGroup>
+    <None Include="../../icon.png" Pack="true" PackagePath="" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
 


### PR DESCRIPTION
- Replace deprecated `PackageIconUrl` with `PackageIcon` and bundle the icon with the package.
- Replace deprecated `PackageLicenseUrl` with the correct `PackageLicenseExpression`.
- Link to NuGet package and license in README.
- Remove extra indendation in README documentation.

Fixes #38 and fixes #39.