### PR TITLE
Add null handling to json serialization

### DIFF
--- a/src/TinyPNG/TinyPngClient.cs
+++ b/src/TinyPNG/TinyPngClient.cs
@@ -5,6 +5,7 @@ using System.Net.Http.Headers;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using TinyPng.Responses;
 
@@ -30,7 +31,8 @@ public class TinyPngClient
         JsonOptions = new JsonSerializerOptions
         {
             PropertyNameCaseInsensitive = true,
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
         };
 
         JsonOptions.Converters.Add(new CustomJsonStringEnumConverter(JsonNamingPolicy.CamelCase));


### PR DESCRIPTION
The move to System.Text.Json from Json.Net for v4 had the unfortunate side-effect of removing null handling, causing issue #21 to re-appear.

This PR adds it back in.